### PR TITLE
Add conditional for assembler make file to support OS X/macOS

### DIFF
--- a/assembler/Makefile
+++ b/assembler/Makefile
@@ -1,7 +1,8 @@
 CC=gcc
 CFLAGS=-Wall -O2 -g -I../common/
 
-ifneq ($(UNAME), Darwin)
+OS := $(shell uname)
+ifeq ($(OS), Darwin)
 LIBS=-ll
 else
 LIBS=-lfl

--- a/assembler/Makefile
+++ b/assembler/Makefile
@@ -1,6 +1,12 @@
 CC=gcc
 CFLAGS=-Wall -O2 -g -I../common/
+
+ifneq ($(UNAME), Darwin)
+LIBS=-ll
+else
 LIBS=-lfl
+endif
+
 LDFLAGS=
 BISON=bison
 BFLAGS=-d


### PR DESCRIPTION
Fixed: The makefile would not run properly on OS X as the -lfl flag is called -ll in OS X.

Note: This has not been tested under Linux or Windows, but OS X.
